### PR TITLE
Custom orientational sampling and extract with tomo mask

### DIFF
--- a/gapstop/constants.py
+++ b/gapstop/constants.py
@@ -46,6 +46,7 @@ IN_TS_SET = 'inTsSet'
 REF_VOL = 'reference'
 IN_MASK = 'mask'
 IN_SCORE_TOMOS = 'inScoreTomos'
+IN_TOMO_MASKS = 'inTomoMasks'
 # Files and extensions
 MRC = '.mrc'
 EM = '.em'

--- a/gapstop/protocols/protocol_extract_coordinates.py
+++ b/gapstop/protocols/protocol_extract_coordinates.py
@@ -40,7 +40,7 @@ from pyworkflow.protocol import PointerParam, IntParam, FloatParam, GT, STEPS_PA
 from pyworkflow.utils import Message, makePath
 from scipion.constants import PYTHON
 from tomo.constants import BOTTOM_LEFT_CORNER
-from tomo.objects import SetOfCoordinates3D, Tomogram, Coordinate3D, SetOfTomograms
+from tomo.objects import SetOfCoordinates3D, Tomogram, Coordinate3D, SetOfTomograms, SetOfTomoMasks
 from tomo.utils import getObjFromRelation
 
 
@@ -60,6 +60,7 @@ class ProtGapStopExtractCoords(ProtGapStopBase):
         super().__init__(**kwargs)
         self.scoreTomoDict = None
         self.tomoSet = None
+        self.tomoMasksDict = None
 
     # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):
@@ -102,6 +103,13 @@ class ProtGapStopExtractCoords(ProtGapStopBase):
                       help='If set to -1, all the coordinates resulting after having applied the particle diameter '
                            'and the score threshold will be saved. Any other case, the first N coordinates, sorted '
                            'by score, will be saved.')
+        form.addParam(IN_TOMO_MASKS, PointerParam,
+                      pointerClass='SetOfTomoMasks',
+                      allowsNull=True,
+                      label='Tomogram masks (opt.)',
+                      help='Optional set of tomogram masks. If provided, coordinates will only be extracted '
+                           'from regions where the mask value is non-zero. Each mask should correspond to a '
+                           'tomogram by its tsId.')
         form.addParallelSection(threads=1, mpi=0)
 
     # --------------------------- INSERT steps functions ----------------------
@@ -125,6 +133,12 @@ class ProtGapStopExtractCoords(ProtGapStopBase):
         scoreTomoSet = self._getFormAttrib(IN_SCORE_TOMOS)
         self.scoreTomoDict = {sTomo.getTsId(): sTomo.clone() for sTomo in scoreTomoSet.iterItems()}
         self.tomoSet = self._getTomosFromRelations()
+        # Initialize tomo masks dictionary if provided
+        tomoMasksSet = self._getFormAttrib(IN_TOMO_MASKS)
+        if tomoMasksSet:
+            self.tomoMasksDict = {tomoMask.getTsId(): tomoMask.clone() for tomoMask in tomoMasksSet.iterItems()}
+        else:
+            self.tomoMasksDict = {}
 
     def extractCoordinatesStep(self, tsId: str):
         sTomo = self.scoreTomoDict[tsId]
@@ -132,6 +146,8 @@ class ProtGapStopExtractCoords(ProtGapStopBase):
         makePath(tsIdExtraDir)
         outParticleListFile = self._getTsIdExtraDirFile(tsId, PARTICLE_LIST_FILE)
         scoresMap = sTomo.getFileName()
+        # Get tomo_mask path if available for this tsId
+        tomoMaskPath = self._getTomoMaskPath(tsId)
         # scores_threshold = {self.scoresThreshold.get()},
         codePatch = f"""
 from cryocat import tmana        
@@ -151,7 +167,8 @@ output_path='{outParticleListFile}',
 output_type='emmotl',
 angles_order='zxz',
 symmetry='{sTomo.getSymmetry()}',
-angles_numbering=0)
+angles_numbering=0,
+tomo_mask={tomoMaskPath})
 """
         extractCoordsPythonFile = join(tsIdExtraDir, 'extractCoords.py')
         with open(extractCoordsPythonFile, "w") as pyFile:
@@ -193,6 +210,14 @@ angles_numbering=0)
     def _getTomosFromRelations(self) -> SetOfTomograms:
         inScoreTomos = self._getFormAttrib(IN_SCORE_TOMOS)
         return getObjFromRelation(inScoreTomos, self, SetOfTomograms)
+
+    def _getTomoMaskPath(self, tsId: str) -> str:
+        """Returns the tomo mask path for a given tsId, or None if not available.
+        The return value is formatted as a string for use in generated Python code."""
+        if self.tomoMasksDict and tsId in self.tomoMasksDict:
+            maskPath = self.tomoMasksDict[tsId].getFileName()
+            return f"'{maskPath}'"
+        return 'None'
 
     def _getScorePercentileValue(self, tomoFileName: str) -> float:
         with mrcfile.mmap(tomoFileName) as mrc:

--- a/gapstop/protocols/protocol_gapstop_tm.py
+++ b/gapstop/protocols/protocol_gapstop_tm.py
@@ -328,9 +328,9 @@ np.savetxt('{angleListFile}', angles, fmt='%.2f', delimiter=',')
             gammaStep = self.gammaStep.get()
 
             # Generate angle arrays in degrees
-            alpha_deg = np.arange(alphaStart, alphaEnd, alphaStep)
+            alpha_deg = np.arange(alphaStart, alphaEnd + alphaStep, alphaStep)  # +step to include end
             beta_deg = np.arange(betaStart, betaEnd + betaStep, betaStep)  # +step to include end
-            gamma_deg = np.arange(gammaStart, gammaEnd, gammaStep)
+            gamma_deg = np.arange(gammaStart, gammaEnd + gammaStep, gammaStep)  # +step to include end
 
             # Generate all combinations (keep in degrees)
             angles = []

--- a/gapstop/protocols/protocol_gapstop_tm.py
+++ b/gapstop/protocols/protocol_gapstop_tm.py
@@ -44,6 +44,7 @@ from pyworkflow.object import Set, String
 from pyworkflow.protocol import PointerParam, FloatParam, StringParam, IntParam, GPU_LIST, BooleanParam, \
     LEVEL_ADVANCED
 from pyworkflow.utils import Message, makePath, getExt, createLink, cyanStr, redStr
+import itertools
 from scipion.constants import PYTHON
 from tomo.objects import SetOfTiltSeries, CTFTomo
 from tomo.utils import getObjFromRelation, getCommonTsAndCtfElements
@@ -145,6 +146,53 @@ class ProtGapStopTemplateMatching(ProtGapStopBase):
                       label='Degree of rotational symmetry',
                       help='From 1, 2, ... to N, representing symmetries C1, C2, ... to CN, respectively. In case '
                            'of non-rotational symmetry, set it ti 1 (default).')
+        # Custom angular sampling parameters
+        form.addParam('useCustomAngSampling', BooleanParam,
+                      default=False,
+                      label='Set custom angular sampling',
+                      help='If set to Yes, you can define custom angular ranges and steps for each Euler angle '
+                           '(alpha, beta, gamma) in ZXZ convention. This overrides the cone angle and cone sampling '
+                           'parameters above.')
+        groupCustomAng = form.addGroup('Custom angular ranges',
+                                       condition='useCustomAngSampling')
+        groupCustomAng.addParam('alphaStart', FloatParam,
+                                default=0,
+                                label='Alpha start (deg.)',
+                                help='Start angle for alpha (Z rotation). Range: [0, 360)')
+        groupCustomAng.addParam('alphaEnd', FloatParam,
+                                default=360,
+                                label='Alpha end (deg.)',
+                                help='End angle for alpha (Z rotation). Range: (0, 360]')
+        groupCustomAng.addParam('alphaStep', FloatParam,
+                                default=10,
+                                label='Alpha step (deg.)',
+                                help='Step size for alpha angle sampling.')
+        groupCustomAng.addParam('betaStart', FloatParam,
+                                default=40,
+                                label='Beta start (deg.)',
+                                help='Start angle for beta (X tilt). Range: [0, 180]. '
+                                     'For example, 40-140 leaves ±50° missing caps.')
+        groupCustomAng.addParam('betaEnd', FloatParam,
+                                default=140,
+                                label='Beta end (deg.)',
+                                help='End angle for beta (X tilt). Range: [0, 180]. '
+                                     'For example, 40-140 leaves ±50° missing caps.')
+        groupCustomAng.addParam('betaStep', FloatParam,
+                                default=10,
+                                label='Beta step (deg.)',
+                                help='Step size for beta angle sampling.')
+        groupCustomAng.addParam('gammaStart', FloatParam,
+                                default=0,
+                                label='Gamma start (deg.)',
+                                help='Start angle for gamma (Z rotation). Range: [0, 360)')
+        groupCustomAng.addParam('gammaEnd', FloatParam,
+                                default=360,
+                                label='Gamma end (deg.)',
+                                help='End angle for gamma (Z rotation). Range: (0, 360]')
+        groupCustomAng.addParam('gammaStep', FloatParam,
+                                default=10,
+                                label='Gamma step (deg.)',
+                                help='Step size for gamma angle sampling.')
         form.addSection(label='Template filtering')
         form.addParam('lowPassFilter', FloatParam,
                       default=20,
@@ -171,9 +219,15 @@ class ProtGapStopTemplateMatching(ProtGapStopBase):
         cRId = self._insertFunctionStep(self.convertReferenceStep,
                                         prerequisites=[],
                                         needsGPU=False)
-        pAngId = self._insertFunctionStep(self.prepareAnglesStep,
-                                          prerequisites=cRId,
-                                          needsGPU=False)
+        # Choose the appropriate angle preparation step based on user choice
+        if self.useCustomAngSampling.get():
+            pAngId = self._insertFunctionStep(self.prepareCustomAngStep,
+                                              prerequisites=cRId,
+                                              needsGPU=False)
+        else:
+            pAngId = self._insertFunctionStep(self.prepareAnglesStep,
+                                              prerequisites=cRId,
+                                              needsGPU=False)
         for tsId in self.tomoDict.keys():
             cInputId = self._insertFunctionStep(self.convertInputStep, tsId,
                                                 prerequisites=pAngId,
@@ -254,6 +308,44 @@ np.savetxt('{angleListFile}', angles, fmt='%.2f', delimiter=',')
             Plugin.runGapStop(self, PYTHON, genAnglesPythonFile, isCryoCatExec=True)
         except Exception as e:
             raise Exception(f'Angles file generation with the exception -> {e}')
+
+    def prepareCustomAngStep(self):
+        """Generate custom angular sampling for template matching (ZXZ convention, radians).
+        User defines custom ranges and steps for each Euler angle (alpha, beta, gamma)."""
+        try:
+            logger.info(cyanStr('Generating the file with custom Euler angles specifying the rotations...'))
+            angleListFile = self._getCustomAngleFile()
+            deg2rad = np.pi / 180.0
+
+            # Get user-defined ranges (end values are exclusive in arange, so we add step to include end)
+            alphaStart = self.alphaStart.get()
+            alphaEnd = self.alphaEnd.get()
+            alphaStep = self.alphaStep.get()
+            betaStart = self.betaStart.get()
+            betaEnd = self.betaEnd.get()
+            betaStep = self.betaStep.get()
+            gammaStart = self.gammaStart.get()
+            gammaEnd = self.gammaEnd.get()
+            gammaStep = self.gammaStep.get()
+
+            # Generate angle arrays in degrees
+            alpha_deg = np.arange(alphaStart, alphaEnd, alphaStep)
+            beta_deg = np.arange(betaStart, betaEnd + betaStep, betaStep)  # +step to include end
+            gamma_deg = np.arange(gammaStart, gammaEnd, gammaStep)
+
+            # Generate all combinations and convert to radians
+            angles = []
+            for a_deg, b_deg, g_deg in itertools.product(alpha_deg, beta_deg, gamma_deg):
+                a = a_deg * deg2rad
+                b = b_deg * deg2rad
+                g = g_deg * deg2rad
+                angles.append([a, b, g])
+
+            angles = np.array(angles)
+            np.savetxt(angleListFile, angles, fmt='%.6f', delimiter=',')
+            logger.info(cyanStr(f'Generated {len(angles)} angular triplets in {angleListFile}'))
+        except Exception as e:
+            raise Exception(f'Custom angles file generation failed with the exception -> {e}')
 
     def convertInputStep(self, tsId: str):
         try:
@@ -368,7 +460,7 @@ drop_nan_columns=True)
                 scoreTomo = GapStopScoreTomogram()
                 scoresMap = self._getResultsFile(tsId, self._getResultsBName(SCORES, tomoNum))
                 anglesMap = self._getResultsFile(tsId, self._getResultsBName(ANGLES, tomoNum))
-                anglesList = self._getCryoCatAngleFile()
+                anglesList = self._getAngleFile()
                 setMRCSamplingRate(scoresMap, tomo.getSamplingRate())  # Update the apix value in file header
                 scoreTomo.setTsId(tsId)
                 scoreTomo.setFileName(scoresMap)
@@ -436,6 +528,17 @@ drop_nan_columns=True)
     def _getCryoCatAngleFile(self) -> str:
         return self._getExtraPath(f'angles_{self.coneSampling.get():.0f}_{self._getSymmetry()}.txt')
 
+    def _getCustomAngleFile(self) -> str:
+        """Returns the path for custom angle file when using custom angular sampling."""
+        return self._getExtraPath(f'custom_angles_{self._getSymmetry()}.txt')
+
+    def _getAngleFile(self) -> str:
+        """Returns the appropriate angle file path based on whether custom sampling is used."""
+        if self.useCustomAngSampling.get():
+            return self._getCustomAngleFile()
+        else:
+            return self._getCryoCatAngleFile()
+
     def _getCryoCatWedgesFiles(self, tsId: str) -> str:
         return join(self._getCurrentTomoDir(tsId), 'wedges.star')
 
@@ -500,7 +603,7 @@ drop_nan_columns=True)
                 join('..', basename(self.maskName)),  # tomo_mask_name
                 f'{self._getSymmetry()}',  # symmetry
                 'zxz',  # angslist_order
-                join('..', basename(self._getCryoCatAngleFile())),  # anglist_name
+                join('..', basename(self._getAngleFile())),  # anglist_name
                 SCORES,  # smap_name
                 ANGLES,  # omap_name
                 self.lowPassFilter.get(),  # lp_rad

--- a/gapstop/protocols/protocol_gapstop_tm.py
+++ b/gapstop/protocols/protocol_gapstop_tm.py
@@ -310,12 +310,11 @@ np.savetxt('{angleListFile}', angles, fmt='%.2f', delimiter=',')
             raise Exception(f'Angles file generation with the exception -> {e}')
 
     def prepareCustomAngStep(self):
-        """Generate custom angular sampling for template matching (ZXZ convention, radians).
+        """Generate custom angular sampling for template matching (ZXZ convention, degrees).
         User defines custom ranges and steps for each Euler angle (alpha, beta, gamma)."""
         try:
             logger.info(cyanStr('Generating the file with custom Euler angles specifying the rotations...'))
             angleListFile = self._getCustomAngleFile()
-            deg2rad = np.pi / 180.0
 
             # Get user-defined ranges (end values are exclusive in arange, so we add step to include end)
             alphaStart = self.alphaStart.get()
@@ -333,16 +332,13 @@ np.savetxt('{angleListFile}', angles, fmt='%.2f', delimiter=',')
             beta_deg = np.arange(betaStart, betaEnd + betaStep, betaStep)  # +step to include end
             gamma_deg = np.arange(gammaStart, gammaEnd, gammaStep)
 
-            # Generate all combinations and convert to radians
+            # Generate all combinations (keep in degrees)
             angles = []
             for a_deg, b_deg, g_deg in itertools.product(alpha_deg, beta_deg, gamma_deg):
-                a = a_deg * deg2rad
-                b = b_deg * deg2rad
-                g = g_deg * deg2rad
-                angles.append([a, b, g])
+                angles.append([a_deg, b_deg, g_deg])
 
             angles = np.array(angles)
-            np.savetxt(angleListFile, angles, fmt='%.6f', delimiter=',')
+            np.savetxt(angleListFile, angles, fmt='%.2f', delimiter=',')
             logger.info(cyanStr(f'Generated {len(angles)} angular triplets in {angleListFile}'))
         except Exception as e:
             raise Exception(f'Custom angles file generation failed with the exception -> {e}')


### PR DESCRIPTION
This PR addressed a couple of issues:

1- During coordinates extraction, it's possible in the original implementation to pass a tomogram mask that will extract coordinates only from ROI (https://github.com/turonova/cryoCAT/blob/main/cryocat/tmana.py#L38). This option was not available in the Scipion version, now added.

2- Restrict angular sampling to a specific range for each angle. This allows a couple of advanced ideas to take place: 1- decomposing the sampling to keep certain unpreleged views, 2- segmenting filaments that run parallel to the XY planes with a limited out-of-plane cone. 

Previous functionalities are maintained. 

Cheers
Mohamad